### PR TITLE
Stop footer covering bottom of menu

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -152,6 +152,7 @@
  */
 .page-content {
   padding: $spacing-unit 0;
+  min-height: 1080px;
 }
 
 .page-heading {


### PR DESCRIPTION
Happens on pages where content AND the browser
window is shorter than the menu.

See: #22 