### PR TITLE
fix(comparison-operators): change => to >=

### DIFF
--- a/js/level1.js
+++ b/js/level1.js
@@ -262,7 +262,7 @@
 
     Earlier we introduced JavaScript's arithmetic operators.  Now comes time to
     introduce you to the next set. JavaScript's Comparison operators' are used
-    to compare values(>, <, <=, =>, ===, !==). Most of them you know from math
+    to compare values(>, <, <=, >=, ===, !==). Most of them you know from math
     classes in school, some of them can be new for you:
 
     * === checks equality, results in true if two values are equal.


### PR DESCRIPTION
Someone pointed out in the Intro workshop today that the 'greater than or equal to' symbol was round the wrong way :) @ButenkoT 